### PR TITLE
inject js from sidecar ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-sidecar",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-sidecar",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "dependencies": {
         "install": "^0.13.0",

--- a/src/index.js
+++ b/src/index.js
@@ -264,3 +264,11 @@ if (document.currentScript && document.currentScript.src) {
     );
   }
 }
+
+window.addEventListener('sidecar::run', function(ext) {
+  try {
+    eval(ext.detail);
+  } catch(err) {
+    console.error('Failed to run JS from Sidecar extension', err);
+  }
+});


### PR DESCRIPTION
This can be used in conjunction with [this Sidecar chrome ext change](https://github.com/statsig-io/sidecar-extension/pull/8) that passes the InjectJS to the client page as a custom Event. 