### PR TITLE
Respect window disableLogging option when autoStart query param is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,7 @@ dist
 # TernJS port file
 .tern-port
 
+# Mac file
+.DS_Store
+
 test-site/

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
   _isMatchingExperiment: function(url, filterType, filters) {
     if (filterType === 'all' || filters.length === 0) {
       return true;
-    }    
+    }
     if (filterType === 'contains') {
       return filters.some((filter) => url.includes(filter));
     } else if (filterType === 'equals') {
@@ -191,7 +191,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
           this.performStyleChange(directive.queryPath, directive.value);
         });
         break;
-      
+
       case 'image-change':
         this._performAfterLoad(() => {
           this.performAttributeChange(
@@ -327,16 +327,16 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
 
     try {
       const user = window?.statsigUser ?? (
-        overrideUserID ? { 
+        overrideUserID ? {
             userID: overrideUserID,
             customIDs: { stableID: overrideUserID }
-          } 
+          }
           : {}
       );
       const options = window?.statsigOptions ?? {};
-      options.disableLogging = !autoStart;
+      options.disableLogging = options.disableLogging ?? !autoStart;
       if (initUrlOverride || logUrlOverride) {
-        options.networkConfig = { 
+        options.networkConfig = {
           initializeUrl: initUrlOverride,
           logEventUrl: logUrlOverride,
         };
@@ -344,7 +344,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
       this._statsigInstance  = new StatsigClient(apiKey, user, options);
       await this._statsigInstance.initializeAsync();
       runStatsigAutoCapture(this._statsigInstance);
-      
+
       this._clientInitialized = true;
       this._flushQueuedEvents();
 
@@ -370,7 +370,7 @@ if (document.currentScript && document.currentScript.src) {
   const multiExpIds = url.searchParams.get('multiexpids');
   const initUrl = url.searchParams.get('initializeurl');
   const logUrl = url.searchParams.get('logeventurl');
-  
+
   const autoStart = url.searchParams.get('autostart') !== '0';
   // Deprecated
   // const autoCapture = url.searchParams.get('autocapture') !== '0';


### PR DESCRIPTION
Noticed that even though I was setting `window.statsigOptions.disableLogging` to `true`, it was actually still `false`. Realized that's because the `autoStart` query param sets it back to `false` if it's not declared.

So instead, this change will respect the window option if it's present.

This was an issue for us because we don't know if we need to disable until runtime, so we couldn't append the option as a query param on the script src.