### PR TITLE
Feature/activate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -271,9 +271,9 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
       return null;
     }
     scConfig.get('activeExperiments', [])
-      .filter(exp => exp.custom_trigger)
+      .filter(exp => exp.customTrigger)
       .forEach(exp => {
-        this.performInjectScript(exp.custom_trigger);
+        this.performInjectScript(exp.customTrigger);
       });
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -263,6 +263,20 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
     }
   },
 
+  _bindCustomTriggers: function() {
+    const scConfig = this._statsigInstance.getDynamicConfig(
+      'sidecar_dynamic_config',
+    );
+    if (!scConfig) {
+      return null;
+    }
+    scConfig.get('activeExperiments', [])
+      .filter(exp => exp.custom_trigger)
+      .forEach(exp => {
+        this.performInjectScript(exp.custom_trigger);
+      });
+  },
+
   processEvent: function(event) {
     if (!event || !event.detail) {
       return false;
@@ -357,6 +371,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
       
       this._clientInitialized = true;
       this._flushQueuedEvents();
+      this._bindCustomTriggers();
 
       if (!expIds) {
         expIds = this._getMatchingExperiments();

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
   getStatsigInstance: function() {
     return this._statsigInstance;
   },
+
   activateExperiment: function(expId) {
     const exp = StatsigSidecar._getAllExperiments().find(exp => {
       if(exp.id === expId) return exp;
@@ -17,6 +18,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
       StatsigSidecar._performExperiments([exp.id]);
     }
   },
+
   _getAllExperiments: function() {
     const scConfig = this._statsigInstance.getDynamicConfig(
       'sidecar_dynamic_config',
@@ -26,6 +28,7 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
     }
     return scConfig.get('activeExperiments', []);
   },
+  
   _getMatchingExperiments: function() {
     const exps = StatsigSidecar._getAllExperiments(),
           matchingExps = [];

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,26 @@ window["StatsigSidecar"] = window["StatsigSidecar"] || {
   getStatsigInstance: function() {
     return this._statsigInstance;
   },
-
-  _getMatchingExperiments: function() {
+  activateExperiment: function(expId) {
+    const exp = StatsigSidecar._getAllExperiments().find(exp => {
+      if(exp.id === expId) return exp;
+    });
+    if(exp) {      
+      StatsigSidecar._performExperiments([exp.id]);
+    }
+  },
+  _getAllExperiments: function() {
     const scConfig = this._statsigInstance.getDynamicConfig(
       'sidecar_dynamic_config',
     );
     if (!scConfig) {
       return null;
     }
-    const exps = scConfig.get('activeExperiments', []);
-    const matchingExps = [];
+    return scConfig.get('activeExperiments', []);
+  },
+  _getMatchingExperiments: function() {
+    const exps = StatsigSidecar._getAllExperiments(),
+          matchingExps = [];
     let url = window.location.href;
     try {
       const u = new URL(url);


### PR DESCRIPTION
Added support for:
- Binding custom trigger. This will require Sidecar extension to a new property to the test entry `sidecar_dynamic_config`. 
- Marking an experiment as "defer", and activating an experiment via `StatsigSidecar.activateExperiment(<key>)`

_example `sidecar_dynamic_config`_
```json
{
  "activeExperiments": [
    {
      "id": "heading_test",
      "filters": [],
      "filterType": "all",
      "preExperimentScript": "function observeElement(e,t){const n=document.querySelector(e);if(!n)return;const r=new IntersectionObserver((e=>{e.forEach((e=>{e.isIntersecting&&(t(),r.unobserve(e.target))}))}),{threshold:.1});r.observe(n)}observeElement('#test-div',(function(){StatsigSidecar.activateExperiment('heading_test')}));",
      "actionType": "inject-script",
      "disableAutoRun": true,
    },
  ],
}
```